### PR TITLE
Relaxed settings

### DIFF
--- a/rules/bestPractices.js
+++ b/rules/bestPractices.js
@@ -32,7 +32,7 @@ module.exports = {
     'no-new-wrappers': 2,
     'no-octal': 2,
     'no-octal-escape': 2,
-    'no-param-reassign': [2, { 'props': true }],
+    'no-param-reassign': [1, { 'props': true }],
     'no-proto': 2,
     'no-redeclare': 2,
     'no-return-assign': [2, 'always'],

--- a/rules/style.js
+++ b/rules/style.js
@@ -36,7 +36,7 @@ module.exports = {
     'no-unneeded-ternary': 2,
     'no-whitespace-before-property': 2,
     'object-curly-spacing': [2, 'always', {
-      'arraysInObjects': false,
+      'arraysInObjects': true,
       'objectsInObjects': false
     }],
     'one-var': [2, 'never'],

--- a/rules/variables.js
+++ b/rules/variables.js
@@ -2,12 +2,9 @@ module.exports = {
   'rules': {
     'no-delete-var': 2,
     'no-label-var': 2,
-    'no-shadow': 2,
     'no-shadow-restricted-names': 2,
     'no-undef': 2,
     'no-undef-init': 2,
-    'no-undefined': 2,
-    'no-unused-vars': [2, { 'args': 'after-used', 'vars': 'all' }],
-    'no-use-before-define': 2
+    'no-unused-vars': [2, { 'args': 'after-used', 'vars': 'all' }]
   }
 }


### PR DESCRIPTION
### Changes

**`no-param-reassign`**

Warn instead of error on param reassignment. There may be much code that reassigns a param name by extending defaults to it, or creating a copy of it in some way. We will reenable this to work, but display a warning instead that it could be doing something dangerous and introduce bugs.

``` javascript
// now allowed with a warning
const withOptions = options => {
  options = Object.assign({}, defaultOptions, options)
}
```

**`arrayInObjects`**

Enforce space after final closing array bracket inside object. This looked too goofy before. Now looks much better

``` javascript
// before
{ my: { nested: [object]}}

// after
{ my: { nested: [object] }}
```

**`no-shadow`**

Allow callbacks to shadow external variables.

``` javascript
// now allowed
const doSomething = tag => {
  // do something with tag
  parentTags().reduce(tag => {

  })
}
```

**`no-undefined`**

Allow the use of `undefined` as an argument. The primary reason for this is for redux store initialization. Since es2015 gave us default arguments, we can signal the reducers they should use a default initial state. We want to allow this

``` javascript
// allows redux reducer pattern as such
const initialState = {}

function myReducer(state = initialState, action) {
  // ...
}
```

**`no-use-before-define`**

Allow function calls to functions defined after they are made. The following is was not previously valid.

``` javascript

function doSomething() {
  doSomethingElse()
}

function doSomethingElse() {
  console.log('I'm doing something')
}
```
